### PR TITLE
chore: migrate Biome to v2

### DIFF
--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -1,3 +1,6 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import type { PortableTextBlock } from "next-sanity";
 import { LikeButton } from "@/components/ui/like-button";
 import { Section } from "@/components/ui/section";
 import { Spacing } from "@/components/ui/spacing";
@@ -8,9 +11,6 @@ import type { Locale } from "@/i18n.config";
 import { getClientIp } from "@/lib/client-ip";
 import { urlForImage, urlForOpenGraphImage } from "@/sanity/lib/image";
 import { loadPostPage } from "@/sanity/lib/store";
-import type { Metadata } from "next";
-import type { PortableTextBlock } from "next-sanity";
-import Image from "next/image";
 
 export async function generateMetadata({
   params,

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -1,3 +1,7 @@
+import { ArrowUpRight } from "lucide-react";
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
 import { Section } from "@/components/ui/section";
 import { Spacing } from "@/components/ui/spacing";
 import { DateFormat } from "@/components/utils/date-format";
@@ -5,10 +9,6 @@ import type { Locale } from "@/i18n.config";
 import { getI18n } from "@/lib/locales/server";
 import { urlForImage } from "@/sanity/lib/image";
 import { loadBlogPage } from "@/sanity/lib/store";
-import { ArrowUpRight } from "lucide-react";
-import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
 
 export async function generateMetadata({
   params,

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,3 +1,9 @@
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import { GeistMono } from "geist/font/mono";
+import { GeistSans } from "geist/font/sans";
+import type { Metadata } from "next";
+import { toPlainText } from "next-sanity";
 import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
 import { ThemeProvider } from "@/components/provider/theme-provider";
@@ -9,12 +15,6 @@ import { cn } from "@/lib/utils";
 import { SubjectivitySerif } from "@/public/font/serif/subjectivity";
 import { urlForOpenGraphImage } from "@/sanity/lib/image";
 import { loadHomePage } from "@/sanity/lib/store";
-import { Analytics } from "@vercel/analytics/react";
-import { SpeedInsights } from "@vercel/speed-insights/next";
-import { GeistMono } from "geist/font/mono";
-import { GeistSans } from "geist/font/sans";
-import type { Metadata } from "next";
-import { toPlainText } from "next-sanity";
 import "../globals.css";
 
 export async function generateMetadata(

--- a/app/[lang]/sitemap.ts
+++ b/app/[lang]/sitemap.ts
@@ -1,5 +1,5 @@
-import { loadPostSlugs } from "@/sanity/lib/store";
 import type { MetadataRoute } from "next";
+import { loadPostSlugs } from "@/sanity/lib/store";
 
 const BASE_URL = "https://erwannrousseau.dev";
 

--- a/app/api/like/route.ts
+++ b/app/api/like/route.ts
@@ -1,8 +1,8 @@
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
 import { getClientIp } from "@/lib/client-ip";
 import { client } from "@/sanity/lib/client";
 import { loadPostLikes } from "@/sanity/lib/store";
-import { revalidateTag } from "next/cache";
-import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
   try {

--- a/app/studio/[[...index]]/page.tsx
+++ b/app/studio/[[...index]]/page.tsx
@@ -9,8 +9,8 @@
  * https://github.com/sanity-io/next-sanity
  */
 
-import config from "@/sanity.config";
 import { NextStudio } from "next-sanity/studio";
+import config from "@/sanity.config";
 
 export default function StudioPage() {
   return <NextStudio config={config} />;

--- a/biome.json
+++ b/biome.json
@@ -1,14 +1,12 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true,
     "defaultBranch": "main"
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,
@@ -21,7 +19,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "warn",
         "noUndeclaredVariables": "error",
@@ -29,8 +27,35 @@
         "useExhaustiveDependencies": "warn"
       },
       "suspicious": {
-        "noConsoleLog": "warn",
-        "noEmptyBlockStatements": "error"
+        "noEmptyBlockStatements": "error",
+        "noConsole": {
+          "level": "warn",
+          "options": {
+            "allow": [
+              "assert",
+              "clear",
+              "count",
+              "countReset",
+              "debug",
+              "dir",
+              "dirxml",
+              "error",
+              "group",
+              "groupCollapsed",
+              "groupEnd",
+              "info",
+              "profile",
+              "profileEnd",
+              "table",
+              "time",
+              "timeEnd",
+              "timeLog",
+              "timeStamp",
+              "trace",
+              "warn"
+            ]
+          }
+        }
       },
       "nursery": {
         "useSortedClasses": {
@@ -43,12 +68,17 @@
         }
       }
     },
-    "ignore": ["sanity.types.ts"]
+    "includes": ["**", "!**/sanity.types.ts"]
   },
   "javascript": {
     "globals": ["React"]
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "files": {
-    "ignore": ["node_modules", "public", ".next"]
+    "includes": ["**", "!**/node_modules", "!**/public", "!**/.next"]
   }
 }

--- a/components/home/connect.tsx
+++ b/components/home/connect.tsx
@@ -1,6 +1,6 @@
+import Link from "next/link";
 import { Section } from "@/components/ui/section";
 import { getI18n } from "@/lib/locales/server";
-import Link from "next/link";
 
 export default async function Connect() {
   const t = await getI18n();

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -1,9 +1,9 @@
+import type { PortableTextBlock } from "next-sanity";
 import { Section } from "@/components/ui/section";
 import { CustomPortableText } from "@/components/utils/custom-portable-text";
-import type { HOME_QUERYResult } from "@/sanity.types";
 
 import { urlForImage } from "@/sanity/lib/image";
-import type { PortableTextBlock } from "next-sanity";
+import type { HOME_QUERYResult } from "@/sanity.types";
 
 export default function Hero({ data }: { data: HOME_QUERYResult }) {
   const backgroundImage = urlForImage(data?.profilePicture)?.url();

--- a/components/home/projects.tsx
+++ b/components/home/projects.tsx
@@ -1,8 +1,8 @@
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
 import { InlineSVG } from "@/components/utils/inline-svg";
 import { getI18n } from "@/lib/locales/server";
 import type { Projects as TProjects } from "@/sanity.types";
-import { ArrowUpRight } from "lucide-react";
-import Link from "next/link";
 
 type ProjectsProps = {
   projects?: TProjects[] | null;

--- a/components/home/works.tsx
+++ b/components/home/works.tsx
@@ -1,10 +1,10 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { DateFormat } from "@/components/utils/date-format";
 import { InlineSVG } from "@/components/utils/inline-svg";
 import { getI18n } from "@/lib/locales/server";
 import { rgbColorToString } from "@/lib/utils";
 import type { Works as TWorks } from "@/sanity.types";
-import Link from "next/link";
 
 type WorksProps = {
   works?: TWorks[] | null;

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,9 +1,9 @@
+import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { Icons } from "@/components/ui/icons";
 import { Spacing } from "@/components/ui/spacing";
 import { ThemeToggle } from "@/components/utils/theme-toggle";
 import { cn } from "@/lib/utils";
-import Link from "next/link";
 import Nav from "./nav";
 
 export default async function Header() {

--- a/components/layout/nav.tsx
+++ b/components/layout/nav.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
 import type { Locale } from "@/i18n.config";
 import { useScopedI18n } from "@/lib/locales/client";
 import { cn } from "@/lib/utils";
-import Link from "next/link";
-import { useParams, usePathname } from "next/navigation";
 import { buttonVariants } from "../ui/button";
 
 export default function Nav() {

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
 
 export interface BadgeLinkProps
   extends React.HTMLAttributes<HTMLAnchorElement> {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useScopedI18n } from "@/lib/locales/client";
-import { cn, copyToClipboard } from "@/lib/utils";
 import { CheckIcon, Copy } from "lucide-react";
 import * as React from "react";
+import { useScopedI18n } from "@/lib/locales/client";
+import { cn, copyToClipboard } from "@/lib/utils";
 import { Button, type ButtonProps } from "./button";
 import {
   Tooltip,

--- a/components/ui/like-button.tsx
+++ b/components/ui/like-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import NumberFlow from "@number-flow/react";
 import { Heart } from "lucide-react";
 import * as React from "react";
+import { cn } from "@/lib/utils";
 
 type Props = React.JSX.IntrinsicElements["button"] & {
   likes: number;

--- a/components/ui/snippet.tsx
+++ b/components/ui/snippet.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import * as React from "react";
 import { useScopedI18n } from "@/lib/locales/client";
 import { copyToClipboard, twx } from "@/lib/utils";
-import * as React from "react";
 
 const SnippetComp = twx.code`relative rounded-md bg-muted px-[0.3rem] py-[0.2rem] font-geist-mono text-sm cursor-pointer active:text-pink-400 break-words`;
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -28,4 +28,4 @@ function TooltipContent({
   );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/components/utils/code-block-wrapper.tsx
+++ b/components/utils/code-block-wrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Icons } from "@/components/ui/icons";
@@ -7,7 +8,6 @@ import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { MAX_NUMBER_OF_LINES } from "@/lib/constants";
 import { useScopedI18n } from "@/lib/locales/client";
 import { cn } from "@/lib/utils";
-import * as React from "react";
 
 type IconKeys = keyof typeof Icons;
 interface CodeBlockProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/components/utils/comments.tsx
+++ b/components/utils/comments.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { Locale } from "@/i18n.config";
 import Giscus from "@giscus/react";
 import { useTheme } from "next-themes";
+import type { Locale } from "@/i18n.config";
 
 interface GithubCommentsProps {
   lang: Locale;

--- a/components/utils/custom-portable-text.tsx
+++ b/components/utils/custom-portable-text.tsx
@@ -1,15 +1,15 @@
-import { BadgeLink } from "@/components/ui/badge";
-import { Snippet } from "@/components/ui/snippet";
-import type { Code } from "@/sanity.types";
-import { urlForImage } from "@/sanity/lib/image";
+import Image from "next/image";
+import Link from "next/link";
 import {
   PortableText,
   type PortableTextBlock,
   type PortableTextComponents,
 } from "next-sanity";
-import Image from "next/image";
-import Link from "next/link";
 import { Suspense } from "react";
+import { BadgeLink } from "@/components/ui/badge";
+import { Snippet } from "@/components/ui/snippet";
+import { urlForImage } from "@/sanity/lib/image";
+import type { Code } from "@/sanity.types";
 import CodeBlock from "./code-block";
 import { CodeBlockWrapper } from "./code-block-wrapper";
 import { CodeSkeleton } from "./code-skeleton";

--- a/components/utils/inline-svg.tsx
+++ b/components/utils/inline-svg.tsx
@@ -10,7 +10,7 @@ export const InlineSVG = ({ value, className }: InlineSVGProps) => {
   }
   return (
     <>
-      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: */}
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: value is trusted Sanity SVG */}
       <div className={className} dangerouslySetInnerHTML={{ __html: value }} />
     </>
   );

--- a/components/utils/locale-switcher.tsx
+++ b/components/utils/locale-switcher.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { type Locale, i18n } from "@/i18n.config";
-import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { i18n, type Locale } from "@/i18n.config";
+import { cn } from "@/lib/utils";
 
 export default function LocaleSwitcher() {
   const pathName = usePathname();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 // middleware.ts
-import { createI18nMiddleware } from "next-international/middleware";
+
 import type { NextRequest } from "next/server";
+import { createI18nMiddleware } from "next-international/middleware";
 import { i18n } from "./i18n.config";
 
 const I18nMiddleware = createI18nMiddleware({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tailwind-merge": "^3.0.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.5.5",
     "@tailwindcss/postcss": "^4.0.0",
     "@tailwindcss/typography": "^0.5.16",
     "@types/negotiator": "^0.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.4
-        version: 1.9.4
+        specifier: ^2.5.5
+        version: 2.5.5
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.3.3
@@ -786,59 +786,59 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -6995,39 +6995,39 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.5.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
   '@bramus/specificity@2.4.2':

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,17 +2,17 @@
  * This configuration is used to for the Sanity Studio that’s mounted on the `/app/studio/[[...index]]/page.tsx` route
  */
 
-// Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
-import { apiVersion, dataset, projectId } from "@/sanity/env";
-import { pageStructure, singletonPlugin } from "@/sanity/plugins/settings";
-import { schema } from "@/sanity/schema";
-import home from "@/sanity/schemas/singletons/home";
 import { codeInput } from "@sanity/code-input";
 import { colorInput } from "@sanity/color-input";
 import { languageFilter } from "@sanity/language-filter";
 import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { structureTool } from "sanity/structure";
+// Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
+import { apiVersion, dataset, projectId } from "@/sanity/env";
+import { pageStructure, singletonPlugin } from "@/sanity/plugins/settings";
+import { schema } from "@/sanity/schema";
+import home from "@/sanity/schemas/singletons/home";
 import { languages } from "./i18n.config";
 
 export default defineConfig({

--- a/sanity/lib/store.ts
+++ b/sanity/lib/store.ts
@@ -1,5 +1,7 @@
+import * as queryStore from "@sanity/react-loader";
 import type { Locale } from "@/i18n.config";
 import { i18n } from "@/i18n.config";
+import { client } from "@/sanity/lib/client";
 import type {
   BLOG_QUERYResult,
   HOME_QUERYResult,
@@ -7,8 +9,6 @@ import type {
   POST_QUERYResult,
   SLUGS_QUERYResult,
 } from "@/sanity.types";
-import { client } from "@/sanity/lib/client";
-import * as queryStore from "@sanity/react-loader";
 import {
   BLOG_QUERY,
   HOME_QUERY,

--- a/sanity/plugins/settings.ts
+++ b/sanity/plugins/settings.ts
@@ -9,7 +9,7 @@ export const singletonPlugin = (types: string[]) => {
   return {
     name: "singletonPlugin",
     document: {
-      // biome-ignore lint/suspicious/noExplicitAny:
+      // biome-ignore lint/suspicious/noExplicitAny: Sanity plugin callback types are unexported.
       newDocumentOptions: (prev: any[], { creationContext }: any) => {
         if (creationContext.type === "global") {
           return prev.filter(
@@ -20,7 +20,7 @@ export const singletonPlugin = (types: string[]) => {
 
         return prev;
       },
-      // biome-ignore lint/suspicious/noExplicitAny:
+      // biome-ignore lint/suspicious/noExplicitAny: Sanity plugin callback types are unexported.
       actions: (prev: any[], { schemaType }: any) => {
         if (types.includes(schemaType)) {
           return prev.filter(({ action }) => action !== "duplicate");
@@ -39,7 +39,7 @@ export const pageStructure = (
     const singletonItems = typeDefArray.map((typeDef) => {
       return (
         S.listItem()
-          // biome-ignore lint/style/noNonNullAssertion:
+          // biome-ignore lint/style/noNonNullAssertion: Sanity document definitions require a title.
           .title(typeDef.title!)
           .icon(typeDef.icon)
           .child(

--- a/sanity/schemas/objects/localizedBlockContent.ts
+++ b/sanity/schemas/objects/localizedBlockContent.ts
@@ -1,5 +1,5 @@
-import { languages } from "@/i18n.config";
 import { defineField, defineType } from "sanity";
+import { languages } from "@/i18n.config";
 
 export default defineType({
   name: "localizedBlockContent",

--- a/sanity/schemas/objects/localizedString.ts
+++ b/sanity/schemas/objects/localizedString.ts
@@ -1,5 +1,5 @@
-import { languages } from "@/i18n.config";
 import { defineField, defineType } from "sanity";
+import { languages } from "@/i18n.config";
 
 export default defineType({
   name: "localizedString",


### PR DESCRIPTION
## Résumé
- Met à jour Biome vers 2.5.5 et migre la configuration v1.
- Préserve les règles, exclusions, Tailwind et l’organisation des imports.
- Applique le tri d’imports v2 requis.

Closes #284

## Validation
- ✅ pnpm check
- ⚠️ pnpm build: compilation réussie, collecte CMS bloquée par NEXT_PUBLIC_SANITY_PROJECT_ID/DATASET absents du worktree.