### PR TITLE
feat(blog): control inline image display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+schema.json

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -67,7 +67,7 @@ export default async function Blog({
                       width={107}
                       height={60}
                       sizes="107px"
-                      className="my-auto rounded-md max-md:hidden"
+                      className="my-auto h-[60px] w-[107px] shrink-0 rounded-md object-cover max-md:hidden"
                     />
                   )}
                   <div>

--- a/components/utils/custom-portable-text.tsx
+++ b/components/utils/custom-portable-text.tsx
@@ -79,15 +79,27 @@ export function CustomPortableText({
           return null;
         }
 
+        const isCompact =
+          value.display === "compact" ||
+          (value.display === undefined && dimensions.height > dimensions.width);
+
         return (
           <div className="my-4 grid w-full place-items-center">
             <Image
-              src={image.width(1600).url()}
+              src={image.width(isCompact ? 640 : 1600).url()}
               alt={value.alt ?? ""}
-              className="h-auto w-full rounded-md"
+              className={
+                isCompact
+                  ? "h-auto w-full max-w-xs rounded-md"
+                  : "h-auto w-full rounded-md"
+              }
               width={dimensions.width}
               height={dimensions.height}
-              sizes="(max-width: 768px) 100vw, 1200px"
+              sizes={
+                isCompact
+                  ? "(max-width: 768px) 100vw, 320px"
+                  : "(max-width: 768px) 100vw, 1200px"
+              }
               loading="lazy"
             />
           </div>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check:fix": "biome check --fix",
     "format": "biome format --fix",
     "schema": "sanity schema extract --force",
-    "typegen": "sanity typegen generate"
+    "typegen": "pnpm schema && sanity typegen generate"
   },
   "dependencies": {
     "@giscus/react": "^3.1.0",

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -88,6 +88,7 @@ export type BlockContent = Array<
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       alt?: string;
+      display?: "normal" | "compact";
       _type: "image";
       _key: string;
     }

--- a/sanity/schemas/objects/blockContent.ts
+++ b/sanity/schemas/objects/blockContent.ts
@@ -63,6 +63,20 @@ export default defineType({
           title: "Alternative Text",
           validation: (rule) => rule.required(),
         },
+        {
+          name: "display",
+          type: "string",
+          title: "Display",
+          description: "Compact keeps portrait screenshots readable.",
+          initialValue: "normal",
+          options: {
+            layout: "radio",
+            list: [
+              { title: "Normal", value: "normal" },
+              { title: "Compact", value: "compact" },
+            ],
+          },
+        },
       ],
     }),
     defineArrayMember({


### PR DESCRIPTION
## Summary

Standardize blog thumbnails and add editor-controlled inline image display.

## Details

- Add Normal and Compact image display options in Sanity Studio.
- Keep legacy portrait images compact until explicitly configured.
- Regenerate Sanity types through a single pnpm command.