### PR TITLE
Fix like count initialization for posts

### DIFF
--- a/app/api/like/route.ts
+++ b/app/api/like/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: NextRequest) {
       await client
         .patch(postId)
         .inc({ likeCount: 1 })
-        .setIfMissing({ likedBy: [] })
+        .setIfMissing({ likeCount: 0, likedBy: [] })
         .append("likedBy", [ip])
         .commit();
     }


### PR DESCRIPTION
## Summary

Ensure post likes initialize `likeCount` when missing.

## Details

- Set `likeCount` to `0` alongside `likedBy` before incrementing.
- Prevent like updates from operating on an undefined counter.

## Testing

Not run (not requested)